### PR TITLE
This needs to be in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "ng-focus-on",
+  "main": "ng-focus-on.js",
+  "version": "0.2.1",
+  "homepage": "https://github.com/goodeggs/ng-focus-on",
+  "authors": [
+    "Max Edmands <github@maxedmands.com>",
+    "Jonathan El-Bizri <github@elbizri.com>"
+  ],
+  "description": "A directive to make angular elements focusable",
+  "keywords": [
+    "angularjs",
+    "focus",
+    "blur",
+    "directive"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "app/bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I noticed that this wasn't in bower,  so I created a bower.json file, pointing to a new release tag (v0.2.1). 

If everything looks good, create a new release from the new tag, and then 

`bower register ng-focus-on https://github.com/goodeggs/ng-focus-on`

And ng-focus will be available via bower! Yay!

http://bower.io/#registering-packages
